### PR TITLE
Fix image display in travel cards

### DIFF
--- a/index.php
+++ b/index.php
@@ -900,6 +900,24 @@ function resetFilters() {
     displayUtazasok(allUtazasok);
 }
 
+// Kép útvonal normalizálása (kezeli: teljes URL, gyökérrel kezdődő, vagy fájlnév)
+function resolveImageSrc(boritokep) {
+    if (!boritokep) {
+        return 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="800" height="220"><rect width="100%" height="100%" fill="%23f0f1f7"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" fill="%239aa3b2" font-family="Arial" font-size="24">Nincs kép</text></svg>';
+    }
+    const value = String(boritokep);
+    // Ha teljes URL vagy gyökérrel kezdődik, hagyjuk
+    if (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('/')) {
+        return value;
+    }
+    // Ha már tartalmaz mappát (pl. borito_kepek/valami.jpg vagy kepek/valami.jpg), hagyjuk
+    if (value.includes('/')) {
+        return value;
+    }
+    // Alapértelmezett mappa
+    return `borito_kepek/${value}`;
+}
+
 function displayUtazasok(utazasok) {
     const container = document.getElementById('utazasok-container');
     container.innerHTML = '';
@@ -914,7 +932,7 @@ function displayUtazasok(utazasok) {
         div.className = 'card';
         div.innerHTML = `
             <div class="card-image-container">
-                <img src="kepek/${utazas.boritokep}" alt="borítókép">
+                <img src="${resolveImageSrc(utazas.boritokep)}" alt="borítókép">
             </div>
             <div class="card-content">
                 <h3>${utazas.utazas_elnevezese}</h3>


### PR DESCRIPTION
Update image path resolution in the frontend to correctly display images from various API response formats and provide a placeholder for missing images.

The previous hardcoded image path in the frontend (`kepek/`) conflicted with the backend's new `borito_kepek/` prefix. This change introduces a flexible `resolveImageSrc` helper to correctly interpret image paths returned by the API, whether they are full URLs, root-relative paths, pre-prefixed paths (e.g., `borito_kepek/foo.jpg`), or plain filenames. It also adds a fallback placeholder for cases where no image is provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-11ea1130-9bf2-4d47-8e75-446cce1ee26d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11ea1130-9bf2-4d47-8e75-446cce1ee26d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

